### PR TITLE
Added the birthday command (Rework)

### DIFF
--- a/source/Commands/BirthdayCommand.ts
+++ b/source/Commands/BirthdayCommand.ts
@@ -22,11 +22,20 @@ export class BirthdayCommand extends AbstractCommand {
 			31, 30, 31, 31,
 			30, 31, 30, 31
 		];
-		if (month > 0 && month < 13 && date > 0 && date <= daysInMonths[month]) {
-			return true
-		} else {
-			return false;
-		}
+		return month > 0 && month < 13 && date > 0 && date <= daysInMonths[month];
+	}
+
+	public static setBirthday(user: User, date: number, month: number) {
+		if (!user.birthday) user.birthday = new Date();
+		user.birthday.setMonth(month);
+		user.birthday.setDate(date);
+		user.save();
+	}
+
+	public static removeBirthday(user: User) {
+		delete user.birthday;
+		user.birthday = null;
+		user.save();
 	}
 
 	public async runInternal(bot: Client, message: Message, messageArray: string[]) {
@@ -36,248 +45,269 @@ export class BirthdayCommand extends AbstractCommand {
 
 		let numberSuffix = ["th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"]; // 1st, 2nd, 3rd etc.
 		let monthNames = ["December", "January", "Febuary", "March", "April", "May", "June", "July", "August", "September", "October", "November"];
-		if (messageArray[0]) {
-			switch (messageArray[0]) {
-				case "set":
-					if (messageArray.length == 4) { // Setting a birthday by ID/tag
+
+		switch (messageArray.length) {
+
+			case 4:
+				switch (messageArray[0]) {
+					case "set":
 						let taggedID: string = HelperFunctions.getID(messageArray[1]);
-						let month = parseInt(messageArray[3]);
 						let date = parseInt(messageArray[2]);
-						if (taggedID != user.discordID) { // Setting somebody else's birthday
-							if (user.permissionLevel >= PermissionLevel.moderator) {
-								if (HelperFunctions.verifyUserID(message.guild, taggedID)) { // A staff member setting somebody else's birthday
-									if (BirthdayCommand.validateBirthday(date, month)) {
-										let taggedUser: User = await this.userService.getUserWithID(taggedID);
-										if (!taggedUser.birthday) taggedUser.birthday = new Date();
-										taggedUser.birthday.setMonth(month);
-										taggedUser.birthday.setDate(date);
-										taggedUser.save();
+						let month = parseInt(messageArray[3]);
 
-										message.channel.send(`<@!${taggedID}>'s birthday has been set.`);
-									} else {
-										message.channel.send("Please provide a valid date.");
-									}
-								} else { // A staff member attempting to set somebody else's birthday
-									message.channel.send("Please provide a valid member.");
-								}
-							} else { // Regular member attempting to set somebody else's birthday
-								message.channel.send("You must be a staff member to set another member's birthday!");
-							}
-						} else { // Setting own birthday (By ID/tag)
-							if (BirthdayCommand.validateBirthday(date, month)) {
-								if (!user.birthday) user.birthday = new Date();
-								user.birthday.setMonth(month);
-								user.birthday.setDate(date);
-								user.save();
+						// Setting own birthday (By ID/tag)
+						if (taggedID == user.discordID) {
 
-								message.channel.send(`Your birthday has been set. (PS. you can set your birthday with \`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`);
-							} else {
-								message.channel.send("Please provide a valid date.");
-							}
+							// Invalid birthday
+							if (!BirthdayCommand.validateBirthday(date, month))
+								return message.channel.send("Please provide a valid date.");
+
+							BirthdayCommand.setBirthday(user, date, month);
+							return message.channel.send(`Your birthday has been set. (PS. you can set your birthday with \`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`);
 						}
-					} else if (messageArray.length == 3) { // Setting own birthday
-						let month = parseInt(messageArray[2]);
-						let date = parseInt(messageArray[1]);
-						if (BirthdayCommand.validateBirthday(date, month)) {
-							if (!user.birthday) user.birthday = new Date();
-							user.birthday.setMonth(month);
-							user.birthday.setDate(date);
-							user.save();
 
-							message.channel.send("Your birthday has been set.");
-						} else {
-							message.channel.send("Please provide a valid date.");
-						}
-					} else { // Failing at setting birthday
-						message.channel.send(`Please provide a complete date. (\`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`);
-					}
-					break;
+						// Regular member attempting to set somebody else's birthday
+						if (user.permissionLevel < PermissionLevel.moderator)
+							return message.channel.send("You must be a staff member to set another member's birthday!");
 
-				case "clear":
-					if (messageArray.length == 2) { // Clearing a birthday by ID/tag
-						let taggedID: string = HelperFunctions.getID(messageArray[1]);
-						if (taggedID != user.discordID) { // Clearing somebody else's birthday
-							if (user.permissionLevel >= PermissionLevel.moderator) {
-								if (HelperFunctions.verifyUserID(message.guild, taggedID)) { // A staff member clearing somebody else's birthday
-									let taggedUser: User = await this.userService.getUserWithID(taggedID);
-									if (taggedUser.birthday) {
-										delete taggedUser.birthday;
-										taggedUser.birthday = null;
-										taggedUser.save();
+						// A staff member attempting to set somebody else's birthday
+						if (!HelperFunctions.verifyUserID(message.guild, taggedID))
+							return message.channel.send("Please provide a valid member.");
 
-										message.channel.send(`<@!${taggedID}>'s birthday has been cleared.`);
-									} else {
-										message.channel.send(`<@!${taggedID}>'s birthday is already cleared.`);
-									}
-								} else { // A staff member attempting to clear somebody else's birthday
-									message.channel.send("Please provide a valid member.");
-								}
-							} else { // Regular member attempting to clear somebody else's birthday
-								message.channel.send("You must be a staff member to clear another member's birthday!");
-							}
-						} else { // Clearing own birthday (By ID/tag)
-							if (user.birthday) {
-								delete user.birthday;
-								user.birthday = null;
-								user.save();
+						// Invalid birthday
+						if (!BirthdayCommand.validateBirthday(date, month))
+							return message.channel.send("Please provide a valid date.");
 
-								message.channel.send(`Your birthday has been cleared. (PS. you can clear your birthday with \`${AbstractCommandOptions.prefix}birthday clear\`)`);
-							} else {
-								message.channel.send("Your birthday is already cleared.");
-							}
-						}
-					} else { // Clearing own birthday
-						if (user.birthday) {
-							delete user.birthday;
-							user.birthday = null;
-							user.save();
-
-							message.channel.send("Your birthday has been cleared.");
-						} else {
-							message.channel.send("Your birthday is already cleared.");
-						}
-					}
-					break;
-
-				case "role":
-					if (messageArray[1]) {
-						switch (messageArray[1]) {
-							case "set":
-								if (user.permissionLevel >= PermissionLevel.moderator) {
-									if (messageArray[2]) {
-										let roleID = HelperFunctions.getID(messageArray[2])
-										if (HelperFunctions.verifyRoleID(message.guild, roleID)) {
-											server.birthdayRoleID = roleID;
-											server.save();
-
-											message.channel.send("The birthday role has been set.");
-										} else {
-											message.channel.send("Please provide a valid role.");
-										}
-									} else {
-										message.channel.send("Please provide a role to set.");
-									}
-								} else {
-									message.channel.send("You must be a staff member to set the birthday role!");
-								}
-								break;
-
-							case "remove":
-								if (user.permissionLevel >= PermissionLevel.moderator) {
-									if (server.birthdayRoleID) {
-										//delete server.birthdayRoleID;
-										server.birthdayRoleID = "";
-										server.save();
-
-										message.channel.send("The birthday role has been removed.");
-									} else {
-										message.channel.send("The birthday role is already cleared.");
-									}
-								} else {
-									message.channel.send("You must be a staff member to remove the birthday role!");
-								}
-								break
-
-							default:
-								message.channel.send("This subcommand is unkown.");
-								break;
-						}
-					} else {
-						if (server.birthdayRoleID) {
-							message.channel.send(`This server's role is currently assigned to '${(await message.guild.roles.fetch(server.birthdayRoleID)).name}' (ID ${server.birthdayRoleID}).`);
-						} else {
-							message.channel.send("There is currently no assigned role for this server.");
-						}
-					}
-					break;
-
-				case "channel":
-					if (messageArray[1]) {
-						switch (messageArray[1]) {
-							case "set":
-								if (user.permissionLevel >= PermissionLevel.moderator) {
-									if (messageArray[2]) {
-										let channelID = HelperFunctions.getID(messageArray[2])
-										if (HelperFunctions.verifyChannelID(message.guild, channelID) && message.guild.channels.cache.get(channelID).type == "text") {
-											server.birthdayChannelID = channelID;
-											server.save();
-
-											message.channel.send("The birthday channel has been set.");
-										} else {
-											message.channel.send("Please provide a valid channel.");
-										}
-									} else {
-										message.channel.send("Please provide a channel to set.");
-									}
-								} else {
-									message.channel.send("You must be a staff member to set the birthday channel!");
-								}
-								break;
-
-							case "remove":
-								if (user.permissionLevel >= PermissionLevel.moderator) {
-									if (server.birthdayChannelID) {
-										server.birthdayChannelID = "";
-										server.save();
-
-										message.channel.send("The birthday channel has been removed.");
-									} else {
-										message.channel.send("The birthday channel is already cleared.");
-									}
-								} else {
-									message.channel.send("You must be a staff member to remove the birthday role!");
-								}
-								break
-
-							default:
-								message.channel.send("This subcommand is unkown.");
-								break;
-						}
-					} else {
-						if (server.birthdayChannelID) {
-							message.channel.send(`This server's channel is currently assigned to '${(await message.guild.channels.cache.get(server.birthdayChannelID)).name}' (ID ${server.birthdayChannelID}).`);
-						} else {
-							message.channel.send("There is currently no assigned channel for this server.");
-						}
-					}
-					break;
-
-				default:
-					let taggedID: string = HelperFunctions.getID(messageArray[0]);
-					if (HelperFunctions.verifyUserID(message.guild, taggedID)) { // Getting the birthday of somebody else
 						let taggedUser: User = await this.userService.getUserWithID(taggedID);
-						if (taggedUser) { // Valid member
-							if (taggedID == id) { //  Looking at own birthday (By ID/tag)
-								if (user.birthday) {
-									message.channel.send(`Your birthday is on the ${user.birthday.getDate()}${numberSuffix[user.birthday.getDate() % 10]} of ${monthNames[user.birthday.getMonth()]}. (PS. you can see your birthday with \`${AbstractCommandOptions.prefix}birthday\`)`);
-								} else {
-									message.channel.send("Please set your birthdate before using this command.");
-								}
-							} else { // Looking at somebody else's birthday
-								if (taggedUser.birthday) {
-									message.channel.send(`<@!${taggedID}>'s birthday is on the ${taggedUser.birthday.getDate()}${numberSuffix[taggedUser.birthday.getDate() % 10]} of ${monthNames[taggedUser.birthday.getMonth()]}.`);
-								} else {
-									message.channel.send(`<@!${taggedID}>'s birthday is unknown.`);
-								}
-							}
-						} else { // Invalid member
-							message.channel.send("Please provide a valid member.");
+
+						BirthdayCommand.setBirthday(taggedUser, date, month);
+						return message.channel.send(`<@!${taggedID}>'s birthday has been set.`);
+
+					default:
+						return message.channel.send(`This subcommand is unkown.`);
+				}
+
+			case 3:
+				switch (messageArray[0]) {
+					// !!birthday set {DD} {MM}
+					case "set":
+						let date = parseInt(messageArray[1]);
+						let month = parseInt(messageArray[2]);
+
+						if (!BirthdayCommand.validateBirthday(date, month))
+							return message.channel.send("Please provide a valid date.");
+
+						BirthdayCommand.setBirthday(user, date, month)
+						return message.channel.send("Your birthday has been set.");
+
+					// !!birthday role set {role}
+					case "role":
+						if (messageArray[1] != "set") break;
+
+						// Not a staff member
+						if (user.permissionLevel < PermissionLevel.moderator)
+							return message.channel.send("You must be a staff member to set the birthday role!");
+
+						let roleID = HelperFunctions.getID(messageArray[2])
+
+						// Invalid role
+						if (!HelperFunctions.verifyRoleID(message.guild, roleID))
+							return message.channel.send("Please provide a valid role.");
+
+						server.birthdayRoleID = roleID;
+						server.save();
+						return message.channel.send("The birthday role has been set.");
+
+					// !!birthday channel set {channel}
+					case "channel":
+						if (messageArray[1] != "set") break;
+
+						// Regular user being naughty
+						if (user.permissionLevel < PermissionLevel.moderator)
+							return message.channel.send("You must be a staff member to set the birthday channel!");
+
+						let channelID = HelperFunctions.getID(messageArray[2])
+
+						// Invalid channel
+						if (!HelperFunctions.verifyChannelID(message.guild, channelID) && message.guild.channels.cache.get(channelID).type == "text")
+							return message.channel.send("Please provide a valid channel.");
+
+						server.birthdayChannelID = channelID;
+						server.save();
+						return message.channel.send("The birthday channel has been set.");
+
+					default:
+						return message.channel.send(`This subcommand is unkown.`);
+				}
+
+			case 2:
+				switch (messageArray[0]) {
+
+					// !!birthday set {DD}
+					case "set":
+						return message.channel.send(`Please provide a complete date. (\`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`);
+
+					// !!birthday clear {user}
+					case "clear":
+						let taggedID: string = HelperFunctions.getID(messageArray[1]);
+
+						// Clearing own birthday (By ID/tag)
+						if (taggedID == user.discordID) {
+
+							// No data to clear
+							if (!user.birthday)
+								return message.channel.send("Your birthday is already cleared.");
+
+							BirthdayCommand.removeBirthday(user);
+							return message.channel.send(`Your birthday has been cleared. (PS. you can clear your birthday with \`${AbstractCommandOptions.prefix}birthday clear\`)`);
 						}
-					} else { // User has put something weird in the command
-						message.channel.send("This subcommand is unkown.");
-					}
-					break;
-			}
-		} else {
-			let user: User = await this.userService.getUser(message.member);
-			if (user.birthday!) {
-				message.channel.send(`Your birthday is on the ${user.birthday.getDate()}${numberSuffix[user.birthday.getDate() % 10]} of ${monthNames[user.birthday.getMonth()]}.`);
-			} else {
-				message.channel.send("Please set your birthdate before using this command.");
-			}
+
+						// A regular user attempting to clear somebody elses's birthday
+						if (user.permissionLevel < PermissionLevel.moderator)
+							return message.channel.send("You must be a staff member to clear another member's birthday!");
+
+						// A staff member attempting to clear somebody else's birthday
+						if (!HelperFunctions.verifyUserID(message.guild, taggedID))
+							return message.channel.send("Please provide a valid member.");
+
+						let taggedUser: User = await this.userService.getUserWithID(taggedID);
+
+						// No data to clear
+						if (!taggedUser.birthday)
+							return message.channel.send(`<@!${taggedID}>'s birthday is already cleared.`)
+
+						// Success!
+						BirthdayCommand.removeBirthday(taggedUser);
+						return message.channel.send(`<@!${taggedID}>'s birthday has been cleared.`);
+
+					case "role":
+						switch (messageArray[1]) {
+
+							// !!birthday role set
+							case "set":
+								// Regular user being naughty
+								if (user.permissionLevel < PermissionLevel.moderator)
+									return message.channel.send("You must be a staff member to set the birthday role!");
+
+								// No role provided
+								return message.channel.send("Please provide a role to set.");
+
+							// !!birthday role remove
+							case "remove":
+								// Regular user being naughty
+								if (user.permissionLevel < PermissionLevel.moderator)
+									return message.channel.send("You must be a staff member to remove the birthday role!");
+
+								// No role to remove
+								if (!server.birthdayRoleID)
+									return message.channel.send("The birthday role is already cleared.");
+
+								//delete server.birthdayRoleID;
+								server.birthdayRoleID = "";
+								server.save();
+								return message.channel.send("The birthday role has been removed.");
+
+							default:
+								return message.channel.send(`This subcommand is unkown.`);
+						}
+
+					case "channel":
+						switch (messageArray[1]) {
+
+							// !!birthday channel set
+							case "set":
+								// Regular user being naughty
+								if (user.permissionLevel < PermissionLevel.moderator)
+									return message.channel.send("You must be a staff member to set the birthday channel!");
+
+								return message.channel.send("Please provide a channel to set.");
+
+							// !!birthday channel remove
+							case "remove":
+								if (user.permissionLevel < PermissionLevel.moderator)
+									return message.channel.send("You must be a staff member to remove the birthday role!");
+
+								if (!server.birthdayChannelID)
+									return message.channel.send("The birthday channel is already cleared.")
+
+								server.birthdayChannelID = "";
+								server.save();
+
+								return message.channel.send("The birthday channel has been removed.");
+
+							default:
+								return message.channel.send("This subcommand is unkown.");
+						}
+
+					default:
+						return message.channel.send(`This subcommand is unkown.`);
+				}
+
+			case 1:
+				switch (messageArray[0]) {
+					// !!birthday set
+					case "set":
+						return message.channel.send(`Please provide a date. (\`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`);
+
+					// !!birthday clear
+					case "clear":
+						// No data to clear
+						if (!user.birthday)
+							return message.channel.send("Your birthday is already cleared.");
+
+						BirthdayCommand.removeBirthday(user);
+						return message.channel.send("Your birthday has been cleared.");
+
+					// !!birthday role
+					case "role":
+						// No role to see
+						if (!server.birthdayRoleID)
+							return message.channel.send("There is currently no assigned role for this server.");
+
+						// Shows the current role
+						return message.channel.send(`This server's role is currently assigned to '${(await message.guild.roles.fetch(server.birthdayRoleID)).name}' (ID ${server.birthdayRoleID}).`);
+
+					// !!birthday channel
+					case "channel":
+						// No channel to see
+						if (!server.birthdayChannelID)
+							return message.channel.send("You must be a staff member to remove the birthday role!");
+
+						// Shows the current channel
+						return message.channel.send(`This server's channel is currently assigned to '${(await message.guild.channels.cache.get(server.birthdayChannelID)).name}' (ID ${server.birthdayChannelID}).`);
+
+					// !!birthday {user}
+					default:
+						let taggedID: string = HelperFunctions.getID(messageArray[0]);
+						if (!HelperFunctions.verifyUserID(message.guild, taggedID))
+							return message.channel.send("Please provide a valid member.");
+
+						if (taggedID == id) { //  Looking at own birthday (By ID/tag)
+							if (user.birthday)
+								return message.channel.send("Please set your birthdate before using this command.");
+
+							return message.channel.send(`Your birthday is on the ${user.birthday.getDate()}${numberSuffix[user.birthday.getDate() % 10]} of ${monthNames[user.birthday.getMonth()]}. (PS. you can see your birthday with \`${AbstractCommandOptions.prefix}birthday\`)`);
+						}
+
+						let taggedUser: User = await this.userService.getUserWithID(taggedID);
+
+						if (!taggedUser.birthday)
+							return message.channel.send(`<@!${taggedID}>'s birthday is unknown.`);
+
+						// Example: @Montori's birthday is on the 1st of January.
+						return message.channel.send(`<@!${taggedID}>'s birthday is on the ${taggedUser.birthday.getDate()}${numberSuffix[taggedUser.birthday.getDate() % 10]} of ${monthNames[taggedUser.birthday.getMonth()]}.`);
+				}
+
+			case 0:
+				if (!user.birthday)
+					return message.channel.send("Please set your birthdate before using this command.");
+
+				return message.channel.send(`Your birthday is on the ${user.birthday.getDate()}${numberSuffix[user.birthday.getDate() % 10]} of ${monthNames[user.birthday.getMonth()]}.`);
+
+			default:
+				return message.channel.send(`This subcommand is unkown.`);
 		}
 	}
-
 }
 
 class BirthdayCommandHelp extends AbstractCommandOptions {

--- a/source/Commands/BirthdayCommand.ts
+++ b/source/Commands/BirthdayCommand.ts
@@ -4,8 +4,6 @@ import { Client, Message, MessageEmbed, GuildMember, Guild, Role } from "discord
 import { UserService } from "../Service/UserService";
 import { User } from "../Material/User";
 import { PermissionLevel } from "../Material/PermissionLevel";
-import { stringify } from "querystring";
-import { Brackets, MongoClient } from "typeorm";
 import { ServerData } from "../Material/ServerData";
 import { ServerDataService } from "../Service/ServerDataService";
 import { HelperFunctions } from "../Material/HelperFunctions";
@@ -14,6 +12,24 @@ export class BirthdayCommand extends AbstractCommand {
 	public commandOptions: BirthdayCommandHelp = new BirthdayCommandHelp();
 	public userService: UserService = UserService.getInstance();
 	public serverDataService: ServerDataService = ServerDataService.getInstance();
+
+	private static numberSuffix = ["th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"]; // 1st, 2nd, 3rd etc.
+
+	private static monthEnum = {
+		DECEMBER: "December",
+		JANUARY: "January",
+		FEBRUARY: "February",
+		MARCH: "March",
+		APRIL: "April",
+		MAY: "May",
+		JUNE: "June",
+		JULY: "July",
+		AUGUST: "August",
+		SEPTEMBER: "September",
+		OCTOBER: "October",
+		NOVEMBER: "November",
+		DECEMBER12: "December"
+	};
 
 	// Verifies that this is a valid date
 	public static validateBirthday(date: number, month: number): boolean {
@@ -43,9 +59,6 @@ export class BirthdayCommand extends AbstractCommand {
 		let server: ServerData = await this.serverDataService.getServerData(message.guild);
 		let id: string = message.author.id;
 
-		let numberSuffix = ["th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"]; // 1st, 2nd, 3rd etc.
-		let monthNames = ["December", "January", "Febuary", "March", "April", "May", "June", "July", "August", "September", "October", "November"];
-
 		switch (messageArray.length) {
 
 			case 4:
@@ -57,48 +70,55 @@ export class BirthdayCommand extends AbstractCommand {
 
 						// Setting own birthday (By ID/tag)
 						if (taggedID == user.discordID) {
+							// Only staff can change their birthdays
+							if (user.birthday && user.permissionLevel < PermissionLevel.moderator)
+								return super.sendPermissionDenied(message);
 
 							// Invalid birthday
 							if (!BirthdayCommand.validateBirthday(date, month))
-								return message.channel.send("Please provide a valid date.");
+								return message.channel.send(super.getFailedEmbed().setDescription("An invalid date was provided."));
 
 							BirthdayCommand.setBirthday(user, date, month);
-							return message.channel.send(`Your birthday has been set. (PS. you can set your birthday with \`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`);
+							return message.channel.send(super.getSuccessEmbed().setDescription(`Your birthday has been set. (PS. you can set your birthday with \`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`));
 						}
 
 						// Regular member attempting to set somebody else's birthday
 						if (user.permissionLevel < PermissionLevel.moderator)
-							return message.channel.send("You must be a staff member to set another member's birthday!");
+							return super.sendPermissionDenied(message);// message.channel.send("You must be a staff member to set another member's birthday!");
 
 						// A staff member attempting to set somebody else's birthday
 						if (!HelperFunctions.verifyUserID(message.guild, taggedID))
-							return message.channel.send("Please provide a valid member.");
+							return message.channel.send(super.getFailedEmbed().setDescription("An invalid member was provided."));
 
 						// Invalid birthday
 						if (!BirthdayCommand.validateBirthday(date, month))
-							return message.channel.send("Please provide a valid date.");
+							return message.channel.send(super.getFailedEmbed().setDescription("An invalid date was provided."));
 
 						let taggedUser: User = await this.userService.getUserWithID(taggedID);
 
 						BirthdayCommand.setBirthday(taggedUser, date, month);
-						return message.channel.send(`<@!${taggedID}>'s birthday has been set.`);
+						return message.channel.send(super.getSuccessEmbed().setDescription(`<@!${taggedID}>'s birthday has been set.`));
 
 					default:
-						return message.channel.send(`This subcommand is unkown.`);
+						return super.sendHelp(message);
 				}
 
 			case 3:
 				switch (messageArray[0]) {
 					// !!birthday set {DD} {MM}
 					case "set":
+						// Only staff can change their birthdays
+						if (user.birthday && user.permissionLevel < PermissionLevel.moderator)
+							return super.sendPermissionDenied(message);
+
 						let date = parseInt(messageArray[1]);
 						let month = parseInt(messageArray[2]);
 
 						if (!BirthdayCommand.validateBirthday(date, month))
-							return message.channel.send("Please provide a valid date.");
+							return message.channel.send(super.getFailedEmbed().setDescription("An invalid date was provided."));
 
 						BirthdayCommand.setBirthday(user, date, month)
-						return message.channel.send("Your birthday has been set.");
+						return message.channel.send(super.getSuccessEmbed().setDescription("Your birthday has been set."));
 
 					// !!birthday role set {role}
 					case "role":
@@ -106,38 +126,39 @@ export class BirthdayCommand extends AbstractCommand {
 
 						// Not a staff member
 						if (user.permissionLevel < PermissionLevel.moderator)
-							return message.channel.send("You must be a staff member to set the birthday role!");
+							return super.sendPermissionDenied(message);// message.channel.send("You must be a staff member to set the birthday role!");
 
 						let roleID = HelperFunctions.getID(messageArray[2])
 
 						// Invalid role
 						if (!HelperFunctions.verifyRoleID(message.guild, roleID))
-							return message.channel.send("Please provide a valid role.");
+							return message.channel.send(super.getFailedEmbed().setDescription("An invalid role was provided"));
 
 						server.birthdayRoleID = roleID;
 						server.save();
-						return message.channel.send("The birthday role has been set.");
+						return message.channel.send(super.getSuccessEmbed().setDescription("The birthday role has been set."));
 
 					// !!birthday channel set {channel}
 					case "channel":
-						if (messageArray[1] != "set") break;
+						if (messageArray[1] != "set")
+							return super.sendHelp(message);
 
 						// Regular user being naughty
 						if (user.permissionLevel < PermissionLevel.moderator)
-							return message.channel.send("You must be a staff member to set the birthday channel!");
+							return super.sendPermissionDenied(message);// message.channel.send("You must be a staff member to set the birthday channel!");
 
 						let channelID = HelperFunctions.getID(messageArray[2])
 
 						// Invalid channel
-						if (!HelperFunctions.verifyChannelID(message.guild, channelID) && message.guild.channels.cache.get(channelID).type == "text")
-							return message.channel.send("Please provide a valid channel.");
+						if (!HelperFunctions.verifyChannelID(message.guild, channelID) && message.guild.channels.resolve(channelID).type == "text")
+							return message.channel.send(super.getFailedEmbed().setDescription("An invalid channel was provided."));
 
 						server.birthdayChannelID = channelID;
 						server.save();
-						return message.channel.send("The birthday channel has been set.");
+						return message.channel.send(super.getSuccessEmbed().setDescription("The birthday channel has been set."));
 
 					default:
-						return message.channel.send(`This subcommand is unkown.`);
+						return super.sendHelp(message);
 				}
 
 			case 2:
@@ -145,10 +166,15 @@ export class BirthdayCommand extends AbstractCommand {
 
 					// !!birthday set {DD}
 					case "set":
-						return message.channel.send(`Please provide a complete date. (\`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`);
+						return message.channel.send(super.getFailedEmbed().setDescription(`An incomplete date was provided. (\`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`));
 
 					// !!birthday clear {user}
 					case "clear":
+
+						// A regular user attempting to clear a birthday
+						if (user.permissionLevel < PermissionLevel.moderator)
+							return super.sendPermissionDenied(message);// message.channel.send("You must be a staff member to clear a member's birthday!");
+
 						let taggedID: string = HelperFunctions.getID(messageArray[1]);
 
 						// Clearing own birthday (By ID/tag)
@@ -156,29 +182,25 @@ export class BirthdayCommand extends AbstractCommand {
 
 							// No data to clear
 							if (!user.birthday)
-								return message.channel.send("Your birthday is already cleared.");
+								return message.channel.send(super.getFailedEmbed().setDescription("Your birthday is already cleared."));
 
 							BirthdayCommand.removeBirthday(user);
-							return message.channel.send(`Your birthday has been cleared. (PS. you can clear your birthday with \`${AbstractCommandOptions.prefix}birthday clear\`)`);
+							return message.channel.send(super.getSuccessEmbed().setDescription(`Your birthday has been cleared. (PS. you can clear your birthday with \`${AbstractCommandOptions.prefix}birthday clear\`)`));
 						}
-
-						// A regular user attempting to clear somebody elses's birthday
-						if (user.permissionLevel < PermissionLevel.moderator)
-							return message.channel.send("You must be a staff member to clear another member's birthday!");
 
 						// A staff member attempting to clear somebody else's birthday
 						if (!HelperFunctions.verifyUserID(message.guild, taggedID))
-							return message.channel.send("Please provide a valid member.");
+							return message.channel.send(super.getFailedEmbed().setDescription("An invalid member was provided."));
 
 						let taggedUser: User = await this.userService.getUserWithID(taggedID);
 
 						// No data to clear
 						if (!taggedUser.birthday)
-							return message.channel.send(`<@!${taggedID}>'s birthday is already cleared.`)
+							return message.channel.send(super.getFailedEmbed().setDescription(`<@!${taggedID}>'s birthday is already cleared.`));
 
 						// Success!
 						BirthdayCommand.removeBirthday(taggedUser);
-						return message.channel.send(`<@!${taggedID}>'s birthday has been cleared.`);
+						return message.channel.send(super.getSuccessEmbed().setDescription(`<@!${taggedID}>'s birthday has been cleared.`));
 
 					case "role":
 						switch (messageArray[1]) {
@@ -187,28 +209,28 @@ export class BirthdayCommand extends AbstractCommand {
 							case "set":
 								// Regular user being naughty
 								if (user.permissionLevel < PermissionLevel.moderator)
-									return message.channel.send("You must be a staff member to set the birthday role!");
+									return super.sendPermissionDenied(message);// message.channel.send("You must be a staff member to set the birthday role!");
 
 								// No role provided
-								return message.channel.send("Please provide a role to set.");
+								return message.channel.send(super.getFailedEmbed().setDescription("A role was not provided."));
 
 							// !!birthday role remove
 							case "remove":
 								// Regular user being naughty
 								if (user.permissionLevel < PermissionLevel.moderator)
-									return message.channel.send("You must be a staff member to remove the birthday role!");
+									return super.sendPermissionDenied(message);// message.channel.send("You must be a staff member to remove the birthday role!");
 
 								// No role to remove
 								if (!server.birthdayRoleID)
-									return message.channel.send("The birthday role is already cleared.");
+									return message.channel.send(super.getFailedEmbed().setDescription("The birthday role has not been set."));
 
 								//delete server.birthdayRoleID;
 								server.birthdayRoleID = "";
 								server.save();
-								return message.channel.send("The birthday role has been removed.");
+								return message.channel.send(super.getSuccessEmbed().setDescription("The birthday role has been removed."));
 
 							default:
-								return message.channel.send(`This subcommand is unkown.`);
+								return super.sendHelp(message);
 						}
 
 					case "channel":
@@ -218,94 +240,98 @@ export class BirthdayCommand extends AbstractCommand {
 							case "set":
 								// Regular user being naughty
 								if (user.permissionLevel < PermissionLevel.moderator)
-									return message.channel.send("You must be a staff member to set the birthday channel!");
+									return super.sendPermissionDenied(message);// message.channel.send("You must be a staff member to set the birthday channel!");
 
-								return message.channel.send("Please provide a channel to set.");
+								return message.channel.send(super.getFailedEmbed().setDescription("Please provide a channel to set."));
 
 							// !!birthday channel remove
 							case "remove":
 								if (user.permissionLevel < PermissionLevel.moderator)
-									return message.channel.send("You must be a staff member to remove the birthday role!");
+									return super.sendPermissionDenied(message);// message.channel.send("You must be a staff member to remove the birthday role!");
 
 								if (!server.birthdayChannelID)
-									return message.channel.send("The birthday channel is already cleared.")
+									return message.channel.send(super.getFailedEmbed().setDescription("The birthday channel is not set."));
 
 								server.birthdayChannelID = "";
 								server.save();
 
-								return message.channel.send("The birthday channel has been removed.");
+								return message.channel.send(super.getSuccessEmbed().setDescription("The birthday channel has been removed."));
 
 							default:
-								return message.channel.send("This subcommand is unkown.");
+								return super.sendHelp(message);
 						}
 
 					default:
-						return message.channel.send(`This subcommand is unkown.`);
+						return super.sendHelp(message);
 				}
 
 			case 1:
 				switch (messageArray[0]) {
 					// !!birthday set
 					case "set":
-						return message.channel.send(`Please provide a date. (\`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`);
+						return message.channel.send(super.getFailedEmbed().setDescription(`Please provide a date. (\`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`));
 
 					// !!birthday clear
 					case "clear":
 						// No data to clear
 						if (!user.birthday)
-							return message.channel.send("Your birthday is already cleared.");
+							return message.channel.send(super.getFailedEmbed().setDescription("Your birthday is not set."));
+
+						// Only staff can clear birthdays
+						if (user.permissionLevel < PermissionLevel.moderator)
+							return super.sendPermissionDenied(message);
 
 						BirthdayCommand.removeBirthday(user);
-						return message.channel.send("Your birthday has been cleared.");
+						return message.channel.send(super.getSuccessEmbed().setDescription("Your birthday has been cleared."));
 
 					// !!birthday role
 					case "role":
 						// No role to see
 						if (!server.birthdayRoleID)
-							return message.channel.send("There is currently no assigned role for this server.");
+							return message.channel.send(super.getFailedEmbed().setDescription("The birthday role is not set."));
 
 						// Shows the current role
-						return message.channel.send(`This server's role is currently assigned to '${(await message.guild.roles.fetch(server.birthdayRoleID)).name}' (ID ${server.birthdayRoleID}).`);
+						return message.channel.send(super.getSuccessEmbed().setDescription(`The birthday role is currently assigned to '${(await message.guild.roles.fetch(server.birthdayRoleID)).name}' (ID ${server.birthdayRoleID}).`));
 
 					// !!birthday channel
 					case "channel":
 						// No channel to see
 						if (!server.birthdayChannelID)
-							return message.channel.send("You must be a staff member to remove the birthday role!");
+							return super.sendPermissionDenied(message);// message.channel.send("You must be a staff member to remove the birthday role!");
 
 						// Shows the current channel
-						return message.channel.send(`This server's channel is currently assigned to '${(await message.guild.channels.cache.get(server.birthdayChannelID)).name}' (ID ${server.birthdayChannelID}).`);
+						return message.channel.send(super.getSuccessEmbed().setDescription(`This server's channel is currently assigned to '${message.guild.channels.resolve(server.birthdayChannelID).name}' (ID ${server.birthdayChannelID}).`));
 
 					// !!birthday {user}
 					default:
 						let taggedID: string = HelperFunctions.getID(messageArray[0]);
 						if (!HelperFunctions.verifyUserID(message.guild, taggedID))
-							return message.channel.send("Please provide a valid member.");
+							return message.channel.send(super.getFailedEmbed().setDescription("An invalid user was provided."));
 
 						if (taggedID == id) { //  Looking at own birthday (By ID/tag)
 							if (user.birthday)
-								return message.channel.send("Please set your birthdate before using this command.");
+								return message.channel.send(super.getFailedEmbed().setDescription("Your birthday has not been set yet."));
 
-							return message.channel.send(`Your birthday is on the ${user.birthday.getDate()}${numberSuffix[user.birthday.getDate() % 10]} of ${monthNames[user.birthday.getMonth()]}. (PS. you can see your birthday with \`${AbstractCommandOptions.prefix}birthday\`)`);
+							return message.channel.send(super.getSuccessEmbed().setDescription(`Your birthday is on the ${user.birthday.getDate()}${BirthdayCommand.numberSuffix[user.birthday.getDate() % 10]} of ${BirthdayCommand.monthEnum[user.birthday.getMonth()]}. (PS. you can see your birthday with \`${AbstractCommandOptions.prefix}birthday\`)`));
 						}
 
 						let taggedUser: User = await this.userService.getUserWithID(taggedID);
 
 						if (!taggedUser.birthday)
-							return message.channel.send(`<@!${taggedID}>'s birthday is unknown.`);
+							return message.channel.send(super.getFailedEmbed().setDescription(`<@!${taggedID}>'s birthday has not been set yet.`));
 
 						// Example: @Montori's birthday is on the 1st of January.
-						return message.channel.send(`<@!${taggedID}>'s birthday is on the ${taggedUser.birthday.getDate()}${numberSuffix[taggedUser.birthday.getDate() % 10]} of ${monthNames[taggedUser.birthday.getMonth()]}.`);
+						return message.channel.send(super.getSuccessEmbed().setDescription(`<@!${taggedID}>'s birthday is on the ${taggedUser.birthday.getDate()}${BirthdayCommand.numberSuffix[taggedUser.birthday.getDate() % 10]} of ${BirthdayCommand.monthEnum[taggedUser.birthday.getMonth()]}.`));
 				}
 
 			case 0:
 				if (!user.birthday)
-					return message.channel.send("Please set your birthdate before using this command.");
+					return message.channel.send(super.getFailedEmbed().setDescription("Your birthday has not been set yet."));
 
-				return message.channel.send(`Your birthday is on the ${user.birthday.getDate()}${numberSuffix[user.birthday.getDate() % 10]} of ${monthNames[user.birthday.getMonth()]}.`);
+				return message.channel.send(super.getSuccessEmbed().setDescription(`Your birthday is on the ${user.birthday.getDate()}${BirthdayCommand.numberSuffix[user.birthday.getDate() % 10]} of ${BirthdayCommand.monthEnum[user.birthday.getMonth()]}.`));
 
 			default:
-				return message.channel.send(`This subcommand is unkown.`);
+				return super.sendHelp(message);
 		}
 	}
 }

--- a/source/Commands/BirthdayCommand.ts
+++ b/source/Commands/BirthdayCommand.ts
@@ -1,0 +1,305 @@
+import { AbstractCommand } from "./AbstractCommand";
+import { AbstractCommandOptions } from "../Material/AbstractCommandOptions";
+import { Client, Message, MessageEmbed, GuildMember, Guild, Role } from "discord.js";
+import { UserService } from "../Service/UserService";
+import { User } from "../Material/User";
+import { PermissionLevel } from "../Material/PermissionLevel";
+import { stringify } from "querystring";
+import { Brackets, MongoClient } from "typeorm";
+import { ServerData } from "../Material/ServerData";
+import { ServerDataService } from "../Service/ServerDataService";
+import { HelperFunctions } from "../Material/HelperFunctions";
+
+export class BirthdayCommand extends AbstractCommand {
+	public commandOptions: BirthdayCommandHelp = new BirthdayCommandHelp();
+	public userService: UserService = UserService.getInstance();
+	public serverDataService: ServerDataService = ServerDataService.getInstance();
+
+	// Verifies that this is a valid date
+	public static validateBirthday(date: number, month: number): boolean {
+		let daysInMonths = [0, // So the array can be 1-indexed
+			31, 29, 31, 30,
+			31, 30, 31, 31,
+			30, 31, 30, 31
+		];
+		if (month > 0 && month < 13 && date > 0 && date <= daysInMonths[month]) {
+			return true
+		} else {
+			return false;
+		}
+	}
+
+	public async runInternal(bot: Client, message: Message, messageArray: string[]) {
+		let user: User = await this.userService.getUser(message.member);
+		let server: ServerData = await this.serverDataService.getServerData(message.guild);
+		let id: string = message.author.id;
+
+		let numberSuffix = ["th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"]; // 1st, 2nd, 3rd etc.
+		let monthNames = ["December", "January", "Febuary", "March", "April", "May", "June", "July", "August", "September", "October", "November"];
+		if (messageArray[0]) {
+			switch (messageArray[0]) {
+				case "set":
+					if (messageArray.length == 4) { // Setting a birthday by ID/tag
+						let taggedID: string = HelperFunctions.getID(messageArray[1]);
+						let month = parseInt(messageArray[3]);
+						let date = parseInt(messageArray[2]);
+						if (taggedID != user.discordID) { // Setting somebody else's birthday
+							if (user.permissionLevel >= PermissionLevel.moderator) {
+								if (HelperFunctions.verifyUserID(message.guild, taggedID)) { // A staff member setting somebody else's birthday
+									if (BirthdayCommand.validateBirthday(date, month)) {
+										let taggedUser: User = await this.userService.getUserWithID(taggedID);
+										if (!taggedUser.birthday) taggedUser.birthday = new Date();
+										taggedUser.birthday.setMonth(month);
+										taggedUser.birthday.setDate(date);
+										taggedUser.save();
+
+										message.channel.send(`<@!${taggedID}>'s birthday has been set.`);
+									} else {
+										message.channel.send("Please provide a valid date.");
+									}
+								} else { // A staff member attempting to set somebody else's birthday
+									message.channel.send("Please provide a valid member.");
+								}
+							} else { // Regular member attempting to set somebody else's birthday
+								message.channel.send("You must be a staff member to set another member's birthday!");
+							}
+						} else { // Setting own birthday (By ID/tag)
+							if (BirthdayCommand.validateBirthday(date, month)) {
+								if (!user.birthday) user.birthday = new Date();
+								user.birthday.setMonth(month);
+								user.birthday.setDate(date);
+								user.save();
+
+								message.channel.send(`Your birthday has been set. (PS. you can set your birthday with \`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`);
+							} else {
+								message.channel.send("Please provide a valid date.");
+							}
+						}
+					} else if (messageArray.length == 3) { // Setting own birthday
+						let month = parseInt(messageArray[2]);
+						let date = parseInt(messageArray[1]);
+						if (BirthdayCommand.validateBirthday(date, month)) {
+							if (!user.birthday) user.birthday = new Date();
+							user.birthday.setMonth(month);
+							user.birthday.setDate(date);
+							user.save();
+
+							message.channel.send("Your birthday has been set.");
+						} else {
+							message.channel.send("Please provide a valid date.");
+						}
+					} else { // Failing at setting birthday
+						message.channel.send(`Please provide a complete date. (\`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\`)`);
+					}
+					break;
+
+				case "clear":
+					if (messageArray.length == 2) { // Clearing a birthday by ID/tag
+						let taggedID: string = HelperFunctions.getID(messageArray[1]);
+						if (taggedID != user.discordID) { // Clearing somebody else's birthday
+							if (user.permissionLevel >= PermissionLevel.moderator) {
+								if (HelperFunctions.verifyUserID(message.guild, taggedID)) { // A staff member clearing somebody else's birthday
+									let taggedUser: User = await this.userService.getUserWithID(taggedID);
+									if (taggedUser.birthday) {
+										delete taggedUser.birthday;
+										taggedUser.birthday = null;
+										taggedUser.save();
+
+										message.channel.send(`<@!${taggedID}>'s birthday has been cleared.`);
+									} else {
+										message.channel.send(`<@!${taggedID}>'s birthday is already cleared.`);
+									}
+								} else { // A staff member attempting to clear somebody else's birthday
+									message.channel.send("Please provide a valid member.");
+								}
+							} else { // Regular member attempting to clear somebody else's birthday
+								message.channel.send("You must be a staff member to clear another member's birthday!");
+							}
+						} else { // Clearing own birthday (By ID/tag)
+							if (user.birthday) {
+								delete user.birthday;
+								user.birthday = null;
+								user.save();
+
+								message.channel.send(`Your birthday has been cleared. (PS. you can clear your birthday with \`${AbstractCommandOptions.prefix}birthday clear\`)`);
+							} else {
+								message.channel.send("Your birthday is already cleared.");
+							}
+						}
+					} else { // Clearing own birthday
+						if (user.birthday) {
+							delete user.birthday;
+							user.birthday = null;
+							user.save();
+
+							message.channel.send("Your birthday has been cleared.");
+						} else {
+							message.channel.send("Your birthday is already cleared.");
+						}
+					}
+					break;
+
+				case "role":
+					if (messageArray[1]) {
+						switch (messageArray[1]) {
+							case "set":
+								if (user.permissionLevel >= PermissionLevel.moderator) {
+									if (messageArray[2]) {
+										let roleID = HelperFunctions.getID(messageArray[2])
+										if (HelperFunctions.verifyRoleID(message.guild, roleID)) {
+											server.birthdayRoleID = roleID;
+											server.save();
+
+											message.channel.send("The birthday role has been set.");
+										} else {
+											message.channel.send("Please provide a valid role.");
+										}
+									} else {
+										message.channel.send("Please provide a role to set.");
+									}
+								} else {
+									message.channel.send("You must be a staff member to set the birthday role!");
+								}
+								break;
+
+							case "remove":
+								if (user.permissionLevel >= PermissionLevel.moderator) {
+									if (server.birthdayRoleID) {
+										//delete server.birthdayRoleID;
+										server.birthdayRoleID = "";
+										server.save();
+
+										message.channel.send("The birthday role has been removed.");
+									} else {
+										message.channel.send("The birthday role is already cleared.");
+									}
+								} else {
+									message.channel.send("You must be a staff member to remove the birthday role!");
+								}
+								break
+
+							default:
+								message.channel.send("This subcommand is unkown.");
+								break;
+						}
+					} else {
+						if (server.birthdayRoleID) {
+							message.channel.send(`This server's role is currently assigned to '${(await message.guild.roles.fetch(server.birthdayRoleID)).name}' (ID ${server.birthdayRoleID}).`);
+						} else {
+							message.channel.send("There is currently no assigned role for this server.");
+						}
+					}
+					break;
+
+				case "channel":
+					if (messageArray[1]) {
+						switch (messageArray[1]) {
+							case "set":
+								if (user.permissionLevel >= PermissionLevel.moderator) {
+									if (messageArray[2]) {
+										let channelID = HelperFunctions.getID(messageArray[2])
+										if (HelperFunctions.verifyChannelID(message.guild, channelID) && message.guild.channels.cache.get(channelID).type == "text") {
+											server.birthdayChannelID = channelID;
+											server.save();
+
+											message.channel.send("The birthday channel has been set.");
+										} else {
+											message.channel.send("Please provide a valid channel.");
+										}
+									} else {
+										message.channel.send("Please provide a channel to set.");
+									}
+								} else {
+									message.channel.send("You must be a staff member to set the birthday channel!");
+								}
+								break;
+
+							case "remove":
+								if (user.permissionLevel >= PermissionLevel.moderator) {
+									if (server.birthdayChannelID) {
+										server.birthdayChannelID = "";
+										server.save();
+
+										message.channel.send("The birthday channel has been removed.");
+									} else {
+										message.channel.send("The birthday channel is already cleared.");
+									}
+								} else {
+									message.channel.send("You must be a staff member to remove the birthday role!");
+								}
+								break
+
+							default:
+								message.channel.send("This subcommand is unkown.");
+								break;
+						}
+					} else {
+						if (server.birthdayChannelID) {
+							message.channel.send(`This server's channel is currently assigned to '${(await message.guild.channels.cache.get(server.birthdayChannelID)).name}' (ID ${server.birthdayChannelID}).`);
+						} else {
+							message.channel.send("There is currently no assigned channel for this server.");
+						}
+					}
+					break;
+
+				default:
+					let taggedID: string = HelperFunctions.getID(messageArray[0]);
+					if (HelperFunctions.verifyUserID(message.guild, taggedID)) { // Getting the birthday of somebody else
+						let taggedUser: User = await this.userService.getUserWithID(taggedID);
+						if (taggedUser) { // Valid member
+							if (taggedID == id) { //  Looking at own birthday (By ID/tag)
+								if (user.birthday) {
+									message.channel.send(`Your birthday is on the ${user.birthday.getDate()}${numberSuffix[user.birthday.getDate() % 10]} of ${monthNames[user.birthday.getMonth()]}. (PS. you can see your birthday with \`${AbstractCommandOptions.prefix}birthday\`)`);
+								} else {
+									message.channel.send("Please set your birthdate before using this command.");
+								}
+							} else { // Looking at somebody else's birthday
+								if (taggedUser.birthday) {
+									message.channel.send(`<@!${taggedID}>'s birthday is on the ${taggedUser.birthday.getDate()}${numberSuffix[taggedUser.birthday.getDate() % 10]} of ${monthNames[taggedUser.birthday.getMonth()]}.`);
+								} else {
+									message.channel.send(`<@!${taggedID}>'s birthday is unknown.`);
+								}
+							}
+						} else { // Invalid member
+							message.channel.send("Please provide a valid member.");
+						}
+					} else { // User has put something weird in the command
+						message.channel.send("This subcommand is unkown.");
+					}
+					break;
+			}
+		} else {
+			let user: User = await this.userService.getUser(message.member);
+			if (user.birthday!) {
+				message.channel.send(`Your birthday is on the ${user.birthday.getDate()}${numberSuffix[user.birthday.getDate() % 10]} of ${monthNames[user.birthday.getMonth()]}.`);
+			} else {
+				message.channel.send("Please set your birthdate before using this command.");
+			}
+		}
+	}
+
+}
+
+class BirthdayCommandHelp extends AbstractCommandOptions {
+	public commandName: string;
+	public description: string;
+	public usage: string;
+	public cooldown: number;
+
+	constructor() {
+		super();
+		this.commandName = "birthday";
+		this.description = "For birthday stuff";
+		this.usage =
+			`${AbstractCommandOptions.prefix}birthday\n` +
+			`${AbstractCommandOptions.prefix}birthday {user}\n` +
+			`${AbstractCommandOptions.prefix}birthday clear\n` +
+			`${AbstractCommandOptions.prefix}birthday clear {user}\n` +
+			`${AbstractCommandOptions.prefix}birthday set {DD} {MM}\n` +
+			`${AbstractCommandOptions.prefix}birthday set {user} {DD} {MM}\n` +
+			`${AbstractCommandOptions.prefix}birthday role set {role}\n` +
+			`${AbstractCommandOptions.prefix}birthday role remove\n` +
+			`${AbstractCommandOptions.prefix}birthday channel set {channel}\n` +
+			`${AbstractCommandOptions.prefix}birthday channel remove`;
+	}
+}

--- a/source/Material/HelperFunctions.ts
+++ b/source/Material/HelperFunctions.ts
@@ -6,14 +6,6 @@ export class HelperFunctions {
 	private static readonly roleRegex =   /^<@&(\d+)>$/;
 	private static readonly idRegex =        /^(\d+)$/;
 
-	// Checks if every character is a number
-	public static isNumeric(input: string): Boolean {
-		for (let i = 0; i < input.length; i++) {
-			if (input[i] < '0' || input[i] > '9') return false; // Every character must be numeric
-		}
-		return true;
-	}
-
 	// Gets an ID from a tag / ID
 	public static getID(input: string): string {
 		if (this.userRegex.test(input)) {
@@ -35,20 +27,20 @@ export class HelperFunctions {
 	}
 
 	// Verifies that a member with this ID is in the server
-	public static verifyUserID(server: Guild, id: string): Boolean {
-		if (server.members.cache.find(u => u.id == id)) return true;
+	public static async verifyUserID(server: Guild, id: string): Promise<Boolean> {
+		if (await server.members.fetch(id)) return true;
 		else return false;
 	}
 
 	// Verifies that a role with this ID is in the server
-	public static verifyRoleID(server: Guild, id: string) {
-		if (server.roles.cache.find(r => r.id == id)) return true;
+	public static async verifyRoleID(server: Guild, id: string): Promise<Boolean> {
+		if (await server.roles.fetch(id)) return true;
 		else return false;
 	}
 
 	// Verifies that a channel with this ID is in the server
-	public static verifyChannelID(server: Guild, id: string) {
-		if (server.channels.cache.find(c => c.id == id)) return true;
+	public static verifyChannelID(server: Guild, id: string): Boolean {
+		if (server.channels.resolve(id)) return true;
 		else return false;
 	}
 }

--- a/source/Material/HelperFunctions.ts
+++ b/source/Material/HelperFunctions.ts
@@ -1,6 +1,11 @@
 import { Guild } from "discord.js";
 
 export class HelperFunctions {
+	private static readonly userRegex =  /^<@!?(\d+)>$/;
+	private static readonly channelRegex = /^<#(\d+)>$/;
+	private static readonly roleRegex =   /^<@&(\d+)>$/;
+	private static readonly idRegex =        /^(\d+)$/;
+
 	// Checks if every character is a number
 	public static isNumeric(input: string): Boolean {
 		for (let i = 0; i < input.length; i++) {
@@ -11,33 +16,22 @@ export class HelperFunctions {
 
 	// Gets an ID from a tag / ID
 	public static getID(input: string): string {
-		if (this.isNumeric(input)) {
-			return input;
-		} else if (
-			(
-				(
-					(
-						(input.length > 3 && !(input[2] == "!" || input[2] == "&")) ||
-						(input.length > 4 && (input[2] == "!" || input[2] == "&"))
-					) && input[1] == "@"
-				) ||
-				(input.length > 2 && input[1] == "#") // Channel
-			) &&
-			input[0] == "<" &&
-			input[input.length - 1] == ">") {
-			let id!: string;
-			if (input[2] == "!" || input[2] == "&") {
-				id = input.substring(3, input.length - 1);
-			} else {
-				id = input.substring(2, input.length - 1);
-			}
-			if (this.isNumeric(id))
-				return id;
-			else
-				return "";
-		} else {
-			return "";
+		if (this.userRegex.test(input)) {
+			let results = this.userRegex.exec(input);
+			return results[1]
 		}
+		if (this.channelRegex.test(input)) {
+			let results = this.channelRegex.exec(input);
+			return results[1]
+		}
+		if (this.roleRegex.test(input)) {
+			let results = this.roleRegex.exec(input);
+			return results[1]
+		}
+		if (this.idRegex.test(input)) {
+			return input;
+		}
+		return "";
 	}
 
 	// Verifies that a member with this ID is in the server

--- a/source/Material/HelperFunctions.ts
+++ b/source/Material/HelperFunctions.ts
@@ -1,0 +1,60 @@
+import { Guild } from "discord.js";
+
+export class HelperFunctions {
+	// Checks if every character is a number
+	public static isNumeric(input: string): Boolean {
+		for (let i = 0; i < input.length; i++) {
+			if (input[i] < '0' || input[i] > '9') return false; // Every character must be numeric
+		}
+		return true;
+	}
+
+	// Gets an ID from a tag / ID
+	public static getID(input: string): string {
+		if (this.isNumeric(input)) {
+			return input;
+		} else if (
+			(
+				(
+					(
+						(input.length > 3 && !(input[2] == "!" || input[2] == "&")) ||
+						(input.length > 4 && (input[2] == "!" || input[2] == "&"))
+					) && input[1] == "@"
+				) ||
+				(input.length > 2 && input[1] == "#") // Channel
+			) &&
+			input[0] == "<" &&
+			input[input.length - 1] == ">") {
+			let id!: string;
+			if (input[2] == "!" || input[2] == "&") {
+				id = input.substring(3, input.length - 1);
+			} else {
+				id = input.substring(2, input.length - 1);
+			}
+			if (this.isNumeric(id))
+				return id;
+			else
+				return "";
+		} else {
+			return "";
+		}
+	}
+
+	// Verifies that a member with this ID is in the server
+	public static verifyUserID(server: Guild, id: string): Boolean {
+		if (server.members.cache.find(u => u.id == id)) return true;
+		else return false;
+	}
+
+	// Verifies that a role with this ID is in the server
+	public static verifyRoleID(server: Guild, id: string) {
+		if (server.roles.cache.find(r => r.id == id)) return true;
+		else return false;
+	}
+
+	// Verifies that a channel with this ID is in the server
+	public static verifyChannelID(server: Guild, id: string) {
+		if (server.channels.cache.find(c => c.id == id)) return true;
+		else return false;
+	}
+}

--- a/source/Material/ServerData.ts
+++ b/source/Material/ServerData.ts
@@ -1,0 +1,26 @@
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from 'typeorm';
+
+@Entity()
+export class ServerData extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    public readonly id!: number;
+
+    @Column({ unique: true })
+    public readonly guildID!: string;
+
+    @Column()
+    public readonly addedDate!: Date;
+
+    @Column({ default: "" })
+    public birthdayChannelID: string;
+
+    @Column({ default: "" })
+    public birthdayRoleID: string;
+
+    constructor(guildID: string) {
+        super();
+
+        this.guildID = guildID;
+        this.addedDate = new Date();
+    }
+}

--- a/source/Material/User.ts
+++ b/source/Material/User.ts
@@ -32,6 +32,9 @@ export class User extends BaseEntity
     @Column({type: "integer", enum: PermissionLevel, default: PermissionLevel.member})
     public permissionLevel!: PermissionLevel;
 
+    @Column()
+    public birthday: Date;
+
     constructor(discordID: string)
     {
         super();

--- a/source/Migration/1588667583203-BirthdayMigration.ts
+++ b/source/Migration/1588667583203-BirthdayMigration.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class BirthdayMigration1588667583203 implements MigrationInterface {
+    name = 'BirthdayMigration1588667583203'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "temporary_user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "discordID" varchar NOT NULL DEFAULT (''), "addedDate" datetime NOT NULL, "lastMessage" datetime NOT NULL, "totalMessages" integer NOT NULL DEFAULT (0), "totalPings" integer NOT NULL DEFAULT (0), "headPats" integer NOT NULL DEFAULT (0), "xp" integer NOT NULL DEFAULT (0), "permissionLevel" varchar CHECK( permissionLevel IN ('0','1','2','3','4','5') ) NOT NULL DEFAULT (0), "birthday" datetime, CONSTRAINT "UQ_43c0d04d88a2beec7ed8431d7f1" UNIQUE ("discordID"))`, undefined);
+        await queryRunner.query(`INSERT INTO "temporary_user"("id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel") SELECT "id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel" FROM "user"`, undefined);
+        await queryRunner.query(`DROP TABLE "user"`, undefined);
+        await queryRunner.query(`ALTER TABLE "temporary_user" RENAME TO "user"`, undefined);
+        await queryRunner.query(`CREATE TABLE "temporary_user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "discordID" varchar NOT NULL DEFAULT (''), "addedDate" datetime NOT NULL, "lastMessage" datetime NOT NULL, "totalMessages" integer NOT NULL DEFAULT (0), "totalPings" integer NOT NULL DEFAULT (0), "headPats" integer NOT NULL DEFAULT (0), "xp" integer NOT NULL DEFAULT (0), "permissionLevel" varchar CHECK( permissionLevel IN ('0','1','2','3','4','5') ) NOT NULL DEFAULT (0), "birthday" datetime, CONSTRAINT "UQ_43c0d04d88a2beec7ed8431d7f1" UNIQUE ("discordID"))`, undefined);
+        await queryRunner.query(`INSERT INTO "temporary_user"("id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel", "birthday") SELECT "id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel", "birthday" FROM "user"`, undefined);
+        await queryRunner.query(`DROP TABLE "user"`, undefined);
+        await queryRunner.query(`ALTER TABLE "temporary_user" RENAME TO "user"`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" RENAME TO "temporary_user"`, undefined);
+        await queryRunner.query(`CREATE TABLE "user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "discordID" varchar NOT NULL DEFAULT (''), "addedDate" datetime NOT NULL, "lastMessage" datetime NOT NULL, "totalMessages" integer NOT NULL DEFAULT (0), "totalPings" integer NOT NULL DEFAULT (0), "headPats" integer NOT NULL DEFAULT (0), "xp" integer NOT NULL DEFAULT (0), "permissionLevel" varchar CHECK( permissionLevel IN ('0','1','2','3','4','5') ) NOT NULL DEFAULT (0), "birthday" datetime, CONSTRAINT "UQ_43c0d04d88a2beec7ed8431d7f1" UNIQUE ("discordID"))`, undefined);
+        await queryRunner.query(`INSERT INTO "user"("id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel", "birthday") SELECT "id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel", "birthday" FROM "temporary_user"`, undefined);
+        await queryRunner.query(`DROP TABLE "temporary_user"`, undefined);
+        await queryRunner.query(`ALTER TABLE "user" RENAME TO "temporary_user"`, undefined);
+        await queryRunner.query(`CREATE TABLE "user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "discordID" varchar NOT NULL DEFAULT (''), "addedDate" datetime NOT NULL, "lastMessage" datetime NOT NULL, "totalMessages" integer NOT NULL DEFAULT (0), "totalPings" integer NOT NULL DEFAULT (0), "headPats" integer NOT NULL DEFAULT (0), "xp" integer NOT NULL DEFAULT (0), "permissionLevel" varchar CHECK( permissionLevel IN ('0','1','2','3','4','5') ) NOT NULL DEFAULT (0), CONSTRAINT "UQ_43c0d04d88a2beec7ed8431d7f1" UNIQUE ("discordID"))`, undefined);
+        await queryRunner.query(`INSERT INTO "user"("id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel") SELECT "id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel" FROM "temporary_user"`, undefined);
+        await queryRunner.query(`DROP TABLE "temporary_user"`, undefined);
+    }
+
+}

--- a/source/Migration/1588733397355-ServerDataMigration.ts
+++ b/source/Migration/1588733397355-ServerDataMigration.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ServerDataMigration1588733397355 implements MigrationInterface {
+    name = 'ServerDataMigration1588733397355'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "server_data" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "guildID" varchar NOT NULL, "addedDate" datetime NOT NULL, "birthdayChannelID" varchar NOT NULL DEFAULT (''), "birthdayRoleID" varchar NOT NULL DEFAULT (''), CONSTRAINT "UQ_3a4e05b4a49d64aa45face88a84" UNIQUE ("guildID"))`, undefined);
+        await queryRunner.query(`CREATE TABLE "temporary_user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "discordID" varchar NOT NULL DEFAULT (''), "addedDate" datetime NOT NULL, "lastMessage" datetime NOT NULL, "totalMessages" integer NOT NULL DEFAULT (0), "totalPings" integer NOT NULL DEFAULT (0), "headPats" integer NOT NULL DEFAULT (0), "xp" integer NOT NULL DEFAULT (0), "permissionLevel" varchar CHECK( permissionLevel IN ('0','1','2','3','4','5') ) NOT NULL DEFAULT (0), "birthday" datetime, CONSTRAINT "UQ_43c0d04d88a2beec7ed8431d7f1" UNIQUE ("discordID"))`, undefined);
+        await queryRunner.query(`INSERT INTO "temporary_user"("id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel", "birthday") SELECT "id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel", "birthday" FROM "user"`, undefined);
+        await queryRunner.query(`DROP TABLE "user"`, undefined);
+        await queryRunner.query(`ALTER TABLE "temporary_user" RENAME TO "user"`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" RENAME TO "temporary_user"`, undefined);
+        await queryRunner.query(`CREATE TABLE "user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "discordID" varchar NOT NULL DEFAULT (''), "addedDate" datetime NOT NULL, "lastMessage" datetime NOT NULL, "totalMessages" integer NOT NULL DEFAULT (0), "totalPings" integer NOT NULL DEFAULT (0), "headPats" integer NOT NULL DEFAULT (0), "xp" integer NOT NULL DEFAULT (0), "permissionLevel" varchar CHECK( permissionLevel IN ('0','1','2','3','4','5') ) NOT NULL DEFAULT (0), "birthday" datetime, CONSTRAINT "UQ_43c0d04d88a2beec7ed8431d7f1" UNIQUE ("discordID"))`, undefined);
+        await queryRunner.query(`INSERT INTO "user"("id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel", "birthday") SELECT "id", "discordID", "addedDate", "lastMessage", "totalMessages", "totalPings", "headPats", "xp", "permissionLevel", "birthday" FROM "temporary_user"`, undefined);
+        await queryRunner.query(`DROP TABLE "temporary_user"`, undefined);
+        await queryRunner.query(`DROP TABLE "server_data"`, undefined);
+    }
+
+}

--- a/source/Service/BirthdayService.ts
+++ b/source/Service/BirthdayService.ts
@@ -1,6 +1,6 @@
 import { UserService } from "./UserService";
 import { ServerDataService } from "./ServerDataService";
-import { Client, TextChannel, GuildMember, Guild } from "discord.js";
+import { Client, TextChannel } from "discord.js";
 import { User } from "../Material/User";
 
 export class BirthdayService {

--- a/source/Service/BirthdayService.ts
+++ b/source/Service/BirthdayService.ts
@@ -1,0 +1,53 @@
+import { MessageService } from "./MessageService";
+import { UserService } from "./UserService";
+import { ServerDataService } from "./ServerDataService";
+import { ServerData } from "../Material/ServerData";
+import { Client, GuildMember, TextChannel, Channel } from "discord.js";
+
+export class BirthdayService {
+	private static instance: BirthdayService;
+	private static userService: UserService = UserService.getInstance();
+	private static serverService: ServerDataService = ServerDataService.getInstance();
+
+	public static getInstance(): BirthdayService {
+		return this.instance;
+	}
+
+	public static async updateBirthdays(bot: Client) {
+		let servers = await this.serverService.getAllServerData();
+		let d = new Date();
+		servers.forEach((s: ServerData, i: number) => {
+			let server = bot.guilds.cache.find(g => g.id == s.guildID);
+			if (s.birthdayChannelID || s.birthdayRoleID) {
+				server.members.cache.forEach(async (u: GuildMember) => {
+					let user = await this.userService.getUser(u);
+					if (user.birthday &&
+						user.birthday.getUTCDate() == d.getUTCDate() &&
+						user.birthday.getUTCMonth() == d.getUTCMonth()) {
+						if (s.birthdayChannelID) {
+							let channel = await bot.channels.cache.get(s.birthdayChannelID);
+							if (channel && channel.type == "text") {
+								(channel as TextChannel).send(`Happy birthday to <@!${user.id}>!`);
+							} else {
+								s.birthdayChannelID = "";
+								s.save();
+							}
+						}
+						if (s.birthdayRoleID) {
+							(await server.members.fetch(user.discordID)).roles.add(s.birthdayRoleID);
+						}
+					}
+					else if (user.birthday &&
+						user.birthday.getUTCDate() - 1 == d.getUTCDate() &&
+						user.birthday.getUTCMonth() == d.getUTCMonth()) {
+						if (s.birthdayRoleID) {
+							await (await server.members.fetch(user.discordID)).roles.remove(s.birthdayRoleID);
+						}
+					}
+				});
+			}
+		});
+
+		setInterval((c: Client) => this.updateBirthdays(c), 24 * 60 * 60 * 1000, bot);
+	}
+}

--- a/source/Service/CommandService.ts
+++ b/source/Service/CommandService.ts
@@ -9,6 +9,7 @@ import { LeaderboardCommand } from "../Commands/LeaderboardCommand";
 import { ActivityCommand } from "../Commands/ActivityCommand";
 import { HelpCommand } from "../Commands/HelpCommand";
 import { PermissionCommand } from "../Commands/PermissionCommand";
+import { BirthdayCommand } from "../Commands/BirthdayCommand";
 
 export class CommandService
 {
@@ -41,6 +42,7 @@ export class CommandService
         this.commandMap.set("setactivity", new ActivityCommand());
         this.commandMap.set("help", new HelpCommand());
         this.commandMap.set("permission", new PermissionCommand());
+        this.commandMap.set("birthday", new BirthdayCommand());
     }
 
     runCommand(name: string, bot: Client, message: Message, args: Array<string>)

--- a/source/Service/ServerDataService.ts
+++ b/source/Service/ServerDataService.ts
@@ -1,0 +1,28 @@
+import { ServerData } from "../Material/ServerData";
+import { Guild } from "discord.js";
+
+export class ServerDataService {
+    private static instance: ServerDataService;
+
+    public static getInstance(): ServerDataService {
+        if (!ServerDataService.instance) {
+            this.instance = new ServerDataService();
+        }
+
+        return this.instance;
+    }
+
+    public async getServerData(guild: Guild): Promise<ServerData> {
+        let foundServer = await ServerData.findOne({ where: { discordID: guild.id } });
+        if (!foundServer) {
+            foundServer = new ServerData(guild.id);
+            foundServer.save();
+        }
+
+        return foundServer;
+    }
+
+    public async getAllServerData() {
+        return ServerData.find();
+    }
+}

--- a/source/Service/UserService.ts
+++ b/source/Service/UserService.ts
@@ -26,4 +26,14 @@ export class UserService
 
         return foundUser;
     }
+
+    public async getUserWithID(id: string): Promise<User> {
+        let foundUser = await User.findOne({ where: { discordID: id } });
+        if (!foundUser) {
+            foundUser = new User(id);
+            foundUser.save();
+        }
+
+        return foundUser;
+    }
 }

--- a/source/bot.ts
+++ b/source/bot.ts
@@ -5,6 +5,7 @@ import { MessageService } from './Service/MessageService';
 import { UserService } from './Service/UserService';
 import { createConnection } from "typeorm";
 import { PerkService } from './Service/PerkService';
+import { BirthdayService } from './Service/BirthdayService';
 
 const bot: Discord.Client = new Discord.Client({disableMentions: "everyone"});
 
@@ -15,8 +16,20 @@ MessageService.init(bot);
 const messageService: MessageService = MessageService.getInstance();
 const dbService: UserService = UserService.getInstance();
 const perkService: PerkService = PerkService.getInstance();
+const birthdayService: BirthdayService = BirthdayService.getInstance();
 
 const connection = createConnection();
+
+let d = new Date();
+d.setDate(d.getDate() + 1);
+d.setUTCHours(0);
+d.setUTCMinutes(0);
+d.setUTCSeconds(0);
+d.setUTCMilliseconds(0);
+
+bot.setTimeout(() => {
+
+},d.getUTCMilliseconds() - new Date().getUTCMilliseconds());
 
 connection.then(connection => connection.runMigrations());
 

--- a/source/bot.ts
+++ b/source/bot.ts
@@ -27,15 +27,15 @@ midnight.setUTCMinutes(0);
 midnight.setUTCSeconds(0);
 midnight.setUTCMilliseconds(0);
 
-bot.setTimeout(() => {
-   BirthdayService.updateBirthdays(bot);
-},midnight.getUTCMilliseconds() - new Date().getUTCMilliseconds());
-
 connection.then(connection => connection.runMigrations());
 
 bot.on("ready", async () =>
 {
    await bot.user.setActivity("Running in testing mode");
+
+   bot.setTimeout(() => {
+      BirthdayService.updateBirthdays(bot);
+   }, midnight.getTime() - new Date().getTime());
 
    console.log("INFO: All services loaded. Bot is ready.")
 });

--- a/source/bot.ts
+++ b/source/bot.ts
@@ -20,16 +20,16 @@ const birthdayService: BirthdayService = BirthdayService.getInstance();
 
 const connection = createConnection();
 
-let d = new Date();
-d.setDate(d.getDate() + 1);
-d.setUTCHours(0);
-d.setUTCMinutes(0);
-d.setUTCSeconds(0);
-d.setUTCMilliseconds(0);
+let midnight = new Date();
+midnight.setDate(midnight.getDate() + 1);
+midnight.setUTCHours(0);
+midnight.setUTCMinutes(0);
+midnight.setUTCSeconds(0);
+midnight.setUTCMilliseconds(0);
 
 bot.setTimeout(() => {
-
-},d.getUTCMilliseconds() - new Date().getUTCMilliseconds());
+   BirthdayService.updateBirthdays(bot);
+},midnight.getUTCMilliseconds() - new Date().getUTCMilliseconds());
 
 connection.then(connection => connection.runMigrations());
 


### PR DESCRIPTION
A birthday command implemented is as per issue https://github.com/Montori/Bottius/issues/12. An easy way to access IDs in arguments has also been implemented as in issue https://github.com/Montori/Bottius/issues/33. This pull request looks a lot better than the last pull request.

**Additions:**
- "ServerData" and "ServerDataService", for manipulating information for servers
- "BirthdayCommand" and "BirthdayService", for handling the birthday commands
- The birthday commands listed in the issue
- "HelperFunctions", convenience functions that can be used globally
- Migrations to add the new data to the database
- Help data for the birthday command
- Some ID based helpers have been added for validating:
  - User IDs
  - Role IDs
  - Channel IDs

**Other notes:**
- Automatic birthday posts are currently untested
- Command order is somewhat changed compared to the original issue
  - !!birthday set channel {channel} -> !!birthday channel set {channel}
  - !!birthday remove channel -> !!birthday remove channel
  - !!birthday set role {role} -> !!birthday channel set {role}
  - !!birthday remove role-> !!birthday remove role
- More commands were added than on the original issue
  - !!birthday
    Views own birthday
  - !!birthday {user}
    Views birthday another user's birthday
  - !!birthday set {DD} {MM}
    Sets own birthday to {DD}/{MM}
  - !!birthday set {user} {DD} {MM}
    Sets a user's birthday to {DD}/{MM}
  - !!birthday clear
    Removes own birthday
  - !!birthday clear {user}
    Clears a user's birthday
- Permissions currently required for updating the birthday role/channel or another person's birthday is moderator or above